### PR TITLE
Change deduplication.py method to remove warning 

### DIFF
--- a/src/img2table/tables/processing/bordered_tables/cells/deduplication.py
+++ b/src/img2table/tables/processing/bordered_tables/cells/deduplication.py
@@ -18,7 +18,7 @@ def deduplicate_cells(df_cells: pl.LazyFrame) -> pl.LazyFrame:
 
     # Create copy of df_cells
     df_cells_cp = (df_cells.clone()
-                   .rename({col: f"{col}_" for col in df_cells.columns})
+                   .rename({col: f"{col}_" for col in df_h_lines.collect_schema().names()})
                    )
 
     if df_cells.collect().height == 0:

--- a/src/img2table/tables/processing/bordered_tables/cells/deduplication.py
+++ b/src/img2table/tables/processing/bordered_tables/cells/deduplication.py
@@ -18,7 +18,7 @@ def deduplicate_cells(df_cells: pl.LazyFrame) -> pl.LazyFrame:
 
     # Create copy of df_cells
     df_cells_cp = (df_cells.clone()
-                   .rename({col: f"{col}_" for col in df_h_lines.collect_schema().names()})
+                   .rename({col: f"{col}_" for col in df_cells.collect_schema().names()})
                    )
 
     if df_cells.collect().height == 0:


### PR DESCRIPTION
Removed warning by using Polar's .collect_schema().names() instead of .columns