### PR TITLE
Fix: handle empty tables and rows to prevent ValueError and TypeError

### DIFF
--- a/src/img2table/tables/processing/bordered_tables/tables/consecutive.py
+++ b/src/img2table/tables/processing/bordered_tables/tables/consecutive.py
@@ -12,6 +12,9 @@ def merge_consecutive_tables(tables: List[Table], contours: List[Cell]) -> List[
     :param contours: list of image contours
     :return: list of processed tables
     """
+    # Filter out empty tables
+    tables = [t for t in tables if len(t.items) > 0]
+
     if len(tables) == 0:
         return []
 

--- a/src/img2table/tables/processing/bordered_tables/tables/implicit.py
+++ b/src/img2table/tables/processing/bordered_tables/tables/implicit.py
@@ -23,6 +23,10 @@ def implicit_rows_lines(table: Table, segment: ImageSegment) -> List[Line]:
                            vertical=False,
                            pct=1)
 
+    # Return early if no whitespaces found
+    if not h_ws:
+        return []
+
     # Create whitespaces at the top or the bottom if they are missing
     if h_ws[0].y1 > segment.y1:
         up_ws = Whitespace(cells=[Cell(x1=min([ws.x1 for ws in h_ws]),

--- a/src/img2table/tables/processing/borderless_tables/__init__.py
+++ b/src/img2table/tables/processing/borderless_tables/__init__.py
@@ -46,8 +46,12 @@ def coherent_table(tb: Table, elements: List[Cell]) -> Optional[Table]:
                 )
 
     if len(rel_rows) > 0:
+        min_row = rel_rows[0].get("min_row")
+        max_row = rel_rows[0].get("max_row")
+        if min_row is None or max_row is None:
+            return None
         # Get new rows
-        new_rows = tb.items[rel_rows[0].get("min_row"):rel_rows[0].get("max_row") + 1]
+        new_rows = tb.items[min_row:max_row + 1]
         if len(new_rows) >= 2:
             return Table(rows=new_rows, borderless=True)
 

--- a/src/img2table/tables/processing/borderless_tables/whitespaces.py
+++ b/src/img2table/tables/processing/borderless_tables/whitespaces.py
@@ -129,6 +129,8 @@ def get_whitespaces(segment: Union[ImageSegment, ColumnGroup], vertical: bool = 
     :param continuous: boolean indicating if only continuous whitespaces are retrieved
     :return: list of vertical or horizontal whitespaces
     """
+    if not segment.elements:
+        return []
     # Flip object coordinates in horizontal case
     if not vertical:
         flipped_elements = [Cell(x1=el.y1, y1=el.x1, x2=el.y2, y2=el.x2) for el in segment.elements]


### PR DESCRIPTION

Encountered following error when processing this file: https://www.ul.com/resources/grid-code-compliance-e-book

Looks like code didn't handle empty tables and rows so this is adding few checks to avoid the crash.

  File "/Users/mj/code/bbox/venv/lib/python3.11/site-packages/img2table/document/base/__init__.py", line 127, in extract_tables
    tables = {idx: TableImage(img=img,
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mj/code/bbox/venv/lib/python3.11/site-packages/img2table/document/base/__init__.py", line 128, in <dictcomp>
    min_confidence=min_confidence).extract_tables(implicit_rows=implicit_rows,
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mj/code/bbox/venv/lib/python3.11/site-packages/img2table/tables/image.py", line 129, in extract_tables
    self.extract_bordered_tables(implicit_rows=implicit_rows,
  File "/Users/mj/code/bbox/venv/lib/python3.11/site-packages/img2table/tables/image.py", line 91, in extract_bordered_tables
    self.tables = merge_consecutive_tables(tables=self.tables,
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mj/code/bbox/venv/lib/python3.11/site-packages/img2table/tables/processing/bordered_tables/tables/consecutive.py", line 19, in merge_consecutive_tables
    seq = iter(sorted(tables, key=lambda t: t.y1))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mj/code/bbox/venv/lib/python3.11/site-packages/img2table/tables/processing/bordered_tables/tables/consecutive.py", line 19, in <lambda>
    seq = iter(sorted(tables, key=lambda t: t.y1))
                                            ^^^^
  File "/Users/mj/code/bbox/venv/lib/python3.11/site-packages/img2table/tables/objects/table.py", line 59, in y1
    return min(map(lambda x: x.y1, self.items))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: min() arg is an empty sequence

