### PR TITLE
Lazily import Pillow so that non Surya installs don't error. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+SHELL := /bin/bash
 VENV = ./activate_venv
 DIR := $(shell pwd)
 export PYTHONPATH := $(DIR)/src

--- a/activate_venv
+++ b/activate_venv
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 if [ "$(uname)" == "Darwin" ]; then
-    source .venv/bin/activate
+    source venv/bin/activate
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    source .venv/bin/activate
+    source venv/bin/activate
 elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
     source venv/Scripts/activate
 elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW64_NT" ]; then

--- a/src/img2table/ocr/surya.py
+++ b/src/img2table/ocr/surya.py
@@ -2,7 +2,6 @@
 import typing
 
 import polars as pl
-from PIL import Image
 
 from img2table.document.base import Document
 from img2table.ocr.base import OCRInstance
@@ -24,6 +23,7 @@ class SuryaOCR(OCRInstance):
             from surya.recognition import RecognitionPredictor
             from surya.detection import DetectionPredictor
             from surya.foundation import FoundationPredictor
+            from PIL import Image
 
         except ModuleNotFoundError as err:
             raise ModuleNotFoundError("Missing dependencies, please install 'img2table[surya]' to use this class.") from err
@@ -41,6 +41,7 @@ class SuryaOCR(OCRInstance):
         self.rec_predictor = RecognitionPredictor(FoundationPredictor())
 
     def content(self, document: Document) -> list["surya.recognition.schema.OCRResult"]:
+        from PIL import Image
         # Get OCR of all images
         return self.rec_predictor(images=[Image.fromarray(img) for img in document.images],
                                   langs=[self.langs],


### PR DESCRIPTION
Fixes `ModuleNotFoundError: No module named 'PIL'` when used in environments without Pillow installed.

Also added some fixes to the dev infrastructure. But this is not complete. Trying to maintain any sort of dev infra without locking dependencies is a hiding to nothing. I don't know what version of ruff last passed the lints (if any), and `surya-ocr==0.17.0` does not work with anything other than `opencv-python-headless==4.11.0.86`.

I would strongly recommend using `uv` for dependency management instead of `make`, `venv`, and `requirements.txt` - if you're happy to switch I can do that in this MR. https://docs.astral.sh/uv/

Thanks